### PR TITLE
Upgrade android plugin, fix for java 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 android.Plugin.androidBuild
 
 // Specifying the Android target Sdk version
-platformTarget in Android := "android-21"
+platformTarget in Android := "android-22"
 
 // Application Name
 name := """scala-android"""
@@ -10,7 +10,7 @@ name := """scala-android"""
 version := "1.0.0"
 
 // Scala version
-scalaVersion := "2.11.4"
+scalaVersion := "2.11.7"
 
 // Repositories for dependencies
 resolvers ++= Seq(Resolver.mavenLocal,
@@ -32,3 +32,7 @@ useProguard in Android := true
 proguardOptions in Android ++= Seq(
   "-ignorewarnings",
   "-keep class scala.Dynamic")
+
+javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+
+scalacOptions += "-target:jvm-1.7"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.3.19")
+addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.4.8")

--- a/project/proguard.sbt
+++ b/project/proguard.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "net.sf.proguard" % "proguard-base" % "5.1"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="21"/>
+        android:targetSdkVersion="22"/>
 
     <application>
 

--- a/src/main/scala/com/fortysevendeg/scala/android/SampleActivity.scala
+++ b/src/main/scala/com/fortysevendeg/scala/android/SampleActivity.scala
@@ -19,7 +19,7 @@ package com.fortysevendeg.scala.android
 import android.app.Activity
 import android.os.Bundle
 
-class SampleActivity extends Activity with TypedViewHolder {
+class SampleActivity extends Activity with TypedFindView {
 
   override def onCreate(bundle: Bundle) {
     super.onCreate(bundle)


### PR DESCRIPTION
Hello, I checked project today from activator and noticed few things
- it doesn't compile with java 8 (source compatibility) 
- it uses old plugin
- it doesn't use new proguard 5.1

so... I fixed this and I'm making pull request for others.

Done:
- upgraded android plugin to 1.4.8
- upgraded proguard to 5.1
- fixed compilation with java 8
- upgraded platform target to version 22
- upgraded scala to 2.11.7
